### PR TITLE
Updated operator manifest

### DIFF
--- a/config/manifests/default.yaml
+++ b/config/manifests/default.yaml
@@ -259,6 +259,7 @@ rules:
   resources:
   - pods
   - services
+  - namespaces
   - configmaps
   - deployments
   - statefulsets
@@ -284,6 +285,7 @@ rules:
   - deployments/status
   - pods/status
   - services/status
+  - namespaces/status
   verbs:
   - get
   - patch


### PR DESCRIPTION
Signed-off-by: dhruv0000 <patel.4@iitj.ac.in>

**Description**
This PR addresses the error while deploying mesh-sync
```
app=meshsync ts=2021-02-25T14:28:57.291756623Z level=info message="Pipeline started"
Error creating pipeline.Error while listing: namespaces.namespaces is forbidden: User "system:serviceaccount:meshery:default" cannot list resource "namespaces" in API group "" at the cluster scope
```

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
